### PR TITLE
feat(domain): add MySQL user and database provisioning during domain …

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -2,14 +2,13 @@ package cmd
 
 import (
 	"fmt"
+	"github.com/spf13/cobra"
 	"os"
 	"path/filepath"
-	"strings"
-
-	"github.com/spf13/cobra"
 	"stackroost/config"
 	"stackroost/internal"
 	"stackroost/internal/logger"
+	"strings"
 )
 
 var rootCmd = &cobra.Command{
@@ -125,6 +124,11 @@ var createDomainCmd = &cobra.Command{
 
 		if err := writeConfigFile(domain, configContent, configGen.GetFileExtension()); err != nil {
 			logger.Error(fmt.Sprintf("Failed to write config file: %v", err))
+			os.Exit(1)
+		}
+
+		if err := internal.CreateMySQLUserAndDatabase(username, password); err != nil {
+			logger.Error(fmt.Sprintf("Database setup failed for %s: %v", username, err))
 			os.Exit(1)
 		}
 

--- a/internal/database.go
+++ b/internal/database.go
@@ -1,0 +1,22 @@
+package internal
+
+import (
+	"fmt"
+	"stackroost/internal/logger"
+)
+func CreateMySQLUserAndDatabase(username, password string) error {
+	logger.Info(fmt.Sprintf("Creating MySQL user and database for '%s'", username))
+
+	createUserCmd := fmt.Sprintf(`CREATE USER IF NOT EXISTS '%s'@'localhost' IDENTIFIED BY '%s';`, username, password)
+	createDBCmd := fmt.Sprintf(`CREATE DATABASE IF NOT EXISTS %s;`, username)
+	grantCmd := fmt.Sprintf(`GRANT ALL PRIVILEGES ON %s.* TO '%s'@'localhost';`, username, username)
+	flushCmd := `FLUSH PRIVILEGES;`
+	fullSQL := fmt.Sprintf("%s %s %s %s", createUserCmd, createDBCmd, grantCmd, flushCmd)
+	mysqlCmd := []string{"-e", fullSQL}
+	if err := RunCommand("sudo", append([]string{"mysql"}, mysqlCmd...)...); err != nil {
+		return fmt.Errorf("failed to create MySQL user or database: %v", err)
+	}
+
+	logger.Success(fmt.Sprintf("MySQL user and database '%s' created", username))
+	return nil
+}


### PR DESCRIPTION
…creation

- Introduced database provisioning in the domain creation flow.
- Added `internal/database.go` to handle MySQL user and database setup.
- MySQL user and database are created with the same name as the extracted domain username.
- Password for the MySQL user is reused from the shell user (`--pass` flag).
- Ensures clean integration with Certbot SSL and virtual host setup.