### PR TITLE
feat: add restart-server command to restart apache, nginx, or caddy v…

### DIFF
--- a/cmd/restart_server.go
+++ b/cmd/restart_server.go
@@ -1,0 +1,52 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"stackroost/internal"
+	"stackroost/internal/logger"
+)
+
+var restartServerCmd = &cobra.Command{
+	Use:   "restart-server",
+	Short: "Restart a specific web server (apache, nginx, or caddy)",
+	Run: func(cmd *cobra.Command, args []string) {
+		server, _ := cmd.Flags().GetString("server")
+
+		if internal.IsNilOrEmpty(server) {
+			logger.Error("Please provide a server type using --server (apache, nginx, or caddy)")
+			os.Exit(1)
+		}
+
+		server = strings.ToLower(server)
+		validServers := map[string]string{
+			"apache": "apache2",
+			"nginx":  "nginx",
+			"caddy":  "caddy",
+		}
+
+		systemName, ok := validServers[server]
+		if !ok {
+			logger.Error("Unsupported server type. Use one of: apache, nginx, or caddy")
+			os.Exit(1)
+		}
+
+		logger.Info(fmt.Sprintf("Restarting %s server...", server))
+		err := internal.RunCommand("sudo", "systemctl", "restart", systemName)
+		if err != nil {
+			logger.Error(fmt.Sprintf("Failed to restart %s: %v", server, err))
+			os.Exit(1)
+		}
+
+		logger.Success(fmt.Sprintf("%s restarted successfully", strings.Title(server)))
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(restartServerCmd)
+	restartServerCmd.Flags().String("server", "", "Web server to restart (apache, nginx, or caddy)")
+	restartServerCmd.MarkFlagRequired("server")
+}


### PR DESCRIPTION
…ia CLI

This commit introduces the `restart-server` CLI command to restart supported web servers:

- Accepts --server flag (apache, nginx, or caddy)
- Maps to system service names (apache2, nginx, caddy)
- Uses `sudo systemctl restart` internally
- Validates server type and shows appropriate log messages

Improves operational control over web servers from within StackRoost CLI.