### PR TITLE
feat(cli): add logs-domain command to tail access and error logs

### DIFF
--- a/cmd/logs_domain.go
+++ b/cmd/logs_domain.go
@@ -1,0 +1,84 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"github.com/spf13/cobra"
+	"stackroost/internal"
+	"stackroost/internal/logger"
+)
+
+var logsDomainCmd = &cobra.Command{
+	Use:   "logs-domain",
+	Short: "View recent access and error logs for a domain",
+	Run: func(cmd *cobra.Command, args []string) {
+		domain, _ := cmd.Flags().GetString("domain")
+		lines, _ := cmd.Flags().GetInt("lines")
+
+		if internal.IsNilOrEmpty(domain) {
+			logger.Error("Please provide a domain using --domain")
+			os.Exit(1)
+		}
+
+		if lines <= 0 {
+			lines = 50
+		}
+
+		server := internal.DetectServerType(domain)
+		if server == "" {
+			logger.Error("Could not detect server type for the domain")
+			os.Exit(1)
+		}
+
+		var accessLogPath, errorLogPath string
+
+		switch server {
+		case "apache":
+			accessLogPath = fmt.Sprintf("/var/log/apache2/%s-access.log", domain)
+			errorLogPath = fmt.Sprintf("/var/log/apache2/%s-error.log", domain)
+		case "nginx":
+			accessLogPath = fmt.Sprintf("/var/log/nginx/%s-access.log", domain)
+			errorLogPath = fmt.Sprintf("/var/log/nginx/%s-error.log", domain)
+		case "caddy":
+			accessLogPath = fmt.Sprintf("/var/log/caddy/%s-access.log", domain)
+			errorLogPath = "" // Caddy typically does not separate error logs
+		default:
+			logger.Error("Unsupported server type")
+			os.Exit(1)
+		}
+
+		// Show access log
+		if _, err := os.Stat(accessLogPath); err == nil {
+		logger.Info(fmt.Sprintf("Access Log (%s):", accessLogPath))
+		if fi, _ := os.Stat(accessLogPath); fi.Size() == 0 {
+			logger.Warn("Access log is empty")
+		} else {
+			internal.RunCommand("sudo", "tail", "-n", fmt.Sprintf("%d", lines), accessLogPath)
+		}
+	} else {
+		logger.Warn("Access log not found")
+	}
+		// Show error log
+		if errorLogPath != "" {
+		if _, err := os.Stat(errorLogPath); err == nil {
+			logger.Info(fmt.Sprintf("Error Log (%s):", errorLogPath))
+			if fi, _ := os.Stat(errorLogPath); fi.Size() == 0 {
+				logger.Warn("Error log is empty")
+			} else {
+				internal.RunCommand("sudo", "tail", "-n", fmt.Sprintf("%d", lines), errorLogPath)
+			}
+		} else {
+			logger.Warn("Error log not found")
+		}
+	} else if server == "caddy" {
+		logger.Info("Caddy does not maintain a separate error log by default")
+	}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(logsDomainCmd)
+	logsDomainCmd.Flags().String("domain", "", "Domain name to view logs for")
+	logsDomainCmd.Flags().Int("lines", 50, "Number of lines to show from each log file")
+	logsDomainCmd.MarkFlagRequired("domain")
+}


### PR DESCRIPTION
Introduces the `logs-domain` CLI command to display access and error logs for a given domain. Supports Apache, Nginx, and Caddy (access logs only).

- Accepts --domain and --lines (default: 100)
- Uses tail to stream recent log entries
- Handles missing or empty logs gracefully
- Compatible with system paths for each supported server type

Example:
  stackroost logs-domain --domain example.com --lines 50