### PR TITLE
feat(cli): add list-users command to show regular shell users

### DIFF
--- a/cmd/list_users.go
+++ b/cmd/list_users.go
@@ -1,0 +1,54 @@
+package cmd
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"os/user"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"stackroost/internal/logger"
+)
+
+var listUsersCmd = &cobra.Command{
+	Use:   "list-users",
+	Short: "List all regular system users (UID ≥ 1000)",
+	Run: func(cmd *cobra.Command, args []string) {
+		file, err := os.Open("/etc/passwd")
+		if err != nil {
+			logger.Error(fmt.Sprintf("Failed to open /etc/passwd: %v", err))
+			return
+		}
+		defer file.Close()
+
+		scanner := bufio.NewScanner(file)
+		logger.Info("Listing non-system shell users (UID ≥ 1000)")
+		for scanner.Scan() {
+			line := scanner.Text()
+			parts := strings.Split(line, ":")
+			if len(parts) < 7 {
+				continue
+			}
+
+			username := parts[0]
+			uidStr := parts[2]
+			shell := parts[6]
+
+			uid, err := strconv.Atoi(uidStr)
+			if err != nil || uid < 1000 {
+				continue
+			}
+
+			if shell == "/bin/bash" || shell == "/bin/sh" {
+				u, _ := user.Lookup(username)
+				logger.Info(fmt.Sprintf("User: %-15s UID: %-5d Shell: %s Home: %s", username, uid, shell, u.HomeDir))
+			}
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(listUsersCmd)
+}


### PR DESCRIPTION
- Introduced `list-users` command to display system users with UID ≥ 1000
- Filters out system accounts and only includes users with valid shell access (/bin/bash or /bin/sh)
- Displays username, UID, shell type, and home directory
- Useful for DevOps to audit regular shell users on the system