### PR TITLE
feat(cli): add check-ssl-expiry command to monitor domain certificate…

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -9,6 +9,7 @@ import (
 	"stackroost/internal"
 	"stackroost/internal/logger"
 	"strings"
+	"stackroost/cmd/ssl"
 )
 
 var rootCmd = &cobra.Command{
@@ -208,6 +209,8 @@ func init() {
 	createDomainCmd.Flags().StringP("server", "s", "apache", "Web server type (e.g., apache, nginx, caddy)")
 	createDomainCmd.Flags().Bool("ssl", false, "Enable Let's Encrypt SSL (Apache/Nginx only)")
 	createDomainCmd.MarkFlagRequired("name")
+	rootCmd.AddCommand(ssl.CheckSSLExpiryCmd)
+
 }
 
 func Execute() {

--- a/cmd/ssl/check_expiry.go
+++ b/cmd/ssl/check_expiry.go
@@ -1,0 +1,51 @@
+package ssl
+
+import (
+	"fmt"
+	"os"
+	"crypto/tls"
+	"time"
+	"github.com/spf13/cobra"
+	"stackroost/internal/logger"
+)
+
+var CheckSSLExpiryCmd = &cobra.Command{
+	Use:   "check-ssl-expiry",
+	Short: "Check the SSL certificate expiry for a domain",
+	Run: func(cmd *cobra.Command, args []string) {
+		domain, _ := cmd.Flags().GetString("domain")
+		if domain == "" {
+			logger.Error("Please provide a domain using --domain")
+			os.Exit(1)
+		}
+		checkSSLExpiry(domain)
+	},
+}
+
+func init() {
+	CheckSSLExpiryCmd.Flags().String("domain", "", "Domain to check SSL expiry for")
+	CheckSSLExpiryCmd.MarkFlagRequired("domain")
+}
+
+func checkSSLExpiry(domain string) {
+	conn, err := tls.Dial("tcp", domain+":443", nil)
+	if err != nil {
+		logger.Error(fmt.Sprintf("Failed to connect: %v", err))
+		os.Exit(1)
+	}
+	defer conn.Close()
+
+	certs := conn.ConnectionState().PeerCertificates
+	if len(certs) == 0 {
+		logger.Error("No SSL certificates found")
+		os.Exit(1)
+	}
+	expiry := certs[0].NotAfter
+	daysLeft := int(time.Until(expiry).Hours() / 24)
+
+	logger.Info(fmt.Sprintf("SSL for %s expires on: %s (%d days left)", domain, expiry.Format(time.RFC1123), daysLeft))
+
+	if daysLeft < 15 {
+		logger.Warn("SSL certificate is expiring soon!")
+	}
+}


### PR DESCRIPTION

Adds a new CLI command `check-ssl-expiry` that allows users to check the SSL certificate expiry date for a given domain. This helps DevOps engineers monitor certificate validity and receive warnings if a cert is close to expiration.

Usage:
  stackroost check-ssl-expiry --domain <your-domain.com>

Includes:
- TLS connection and certificate inspection
- Domain flag with validation
- Warning if certificate expires in less than 15 days