### PR TITLE
feat(cli): add test-email command to check mail capability

### DIFF
--- a/cmd/email/test_email.go
+++ b/cmd/email/test_email.go
@@ -1,0 +1,41 @@
+package email
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+
+	"github.com/spf13/cobra"
+	"stackroost/internal/logger"
+)
+
+
+var TestEmailCmd = &cobra.Command{
+	Use:   "test-email",
+	Short: "Check if email capability is available on this system (mail/sendmail/msmtp)",
+	Run: func(cmd *cobra.Command, args []string) {
+		mailers := []string{"mail", "sendmail", "msmtp"}
+		found := false
+
+		for _, bin := range mailers {
+			_, err := exec.LookPath(bin)
+			if err == nil {
+				logger.Success(fmt.Sprintf("Mailer available: %s", bin))
+				found = true
+			}
+		}
+
+		if !found {
+			logger.Warn("No mail sending utilities found (mail/sendmail/msmtp)")
+			logger.Info("You can install one, e.g., `sudo apt install mailutils` or `sendmail`")
+			os.Exit(1)
+		}
+
+		logger.Info("Email sending capability appears to be available")
+	},
+}
+
+func init() {
+	TestEmailCmd.Flags().String("to", "", "Recipient email address")
+	TestEmailCmd.MarkFlagRequired("to")
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"stackroost/cmd/ssl"
 	"stackroost/cmd/logs"
+	"stackroost/cmd/email"
 )
 
 var rootCmd = &cobra.Command{
@@ -211,7 +212,8 @@ func init() {
 	createDomainCmd.Flags().Bool("ssl", false, "Enable Let's Encrypt SSL (Apache/Nginx only)")
 	createDomainCmd.MarkFlagRequired("name")
 	rootCmd.AddCommand(ssl.CheckSSLExpiryCmd)
-		rootCmd.AddCommand(logs.AnalyzeTrafficCmd)
+	rootCmd.AddCommand(logs.AnalyzeTrafficCmd)
+	rootCmd.AddCommand(email.TestEmailCmd)
 }
 
 func Execute() {


### PR DESCRIPTION
Added a new test-email CLI command that checks if the system has mail utilities installed (mail, sendmail, msmtp). This command does not send an email but simply verifies the availability of outbound mail capability on the server. Useful for verifying mail setup without triggering any actual message.